### PR TITLE
Add dx, xlim, ylim, and zlim as optional inputs.

### DIFF
--- a/analysisinput.txt
+++ b/analysisinput.txt
@@ -1,4 +1,8 @@
-path='M03/'
-vmax=15
-dv=0.25
-numframe=1000
+path='/srv/data/simulation/dHybridR/2021.05.Perp_Shocks/Batch02/M06_th45/'
+vmax=25
+dv=0.5
+numframe=2000
+dx=0.5
+xlim=39.0,43.0
+ylim=0.0,3.0
+zlim=0.0,3.0

--- a/generateFPC.py
+++ b/generateFPC.py
@@ -10,7 +10,7 @@ import lib.fieldtransformfunctions as ftf
 # load data
 #-------------------------------------------------------------------------------
 #load path
-path,vmax,dv,numframe = lf.analysis_input()
+path,vmax,dv,numframe,dx,xlim,ylim,zlim = lf.analysis_input()
 path_fields = path
 path_particles = path+"Output/Raw/Sp01/raw_sp01_{:08d}.h5"
 
@@ -22,8 +22,14 @@ dfields = lf.field_loader(path=path_fields,num=numframe)
 all_dfields = lf.all_dfield_loader(path=path_fields, verbose=False)
 
 #Load slice of particle data
-dparticles = lf.readSliceOfParticles(path_particles, numframe, dfields['ex_xx'][0], dfields['ex_xx'][-1], dfields['ex_yy'][0], dfields['ex_yy'][1], dfields['ex_zz'][0], dfields['ex_zz'][1])
-
+if xlim is not None and ylim is not None and zlim is not None:
+    dparticles = lf.readSliceOfParticles(path_particles, numframe, xlim[0], xlim[1], ylim[0], ylim[1], zlim[0], zlim[1])
+#Load only a slice in x but all of y and z
+elif xlim is not None and ylim is None and zlim is None:
+    dparticles = lf.readSliceOfParticles(path_particles, numframe, xlim[0], xlim[1], dfields['ex_yy'][0], dfields['ex_yy'][-1], dfields['ex_zz'][0], dfields['ex_zz'][-1])
+#Load all the particles
+else:
+    dparticles = lf.readParticles(path_particles, numframe)
 #-------------------------------------------------------------------------------
 # estimate shock vel and lorentz transform
 #-------------------------------------------------------------------------------
@@ -41,8 +47,11 @@ all_dfields['dfields'] = _fields
 # do FPC analysis
 #-------------------------------------------------------------------------------
 print("Doing FPC analysis for each slice of x...")
-dx = dfields['ex_xx'][1]-dfields['ex_xx'][0] #assumes rectangular grid thats uniform for all fields
-CEx, CEy, CEz, x, Hist, vx, vy, vz = af.compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock)
+if dx is None:
+    #Assumes rectangular grid that is uniform for all fields
+    #If dx not specified, just use the grid cell spacing for the EM fields
+    dx = dfields['ex_xx'][1]-dfields['ex_xx'][0]
+CEx, CEy, CEz, x, Hist, vx, vy, vz = af.compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock, xlim, ylim, zlim)
 
 #-------------------------------------------------------------------------------
 # Convert to old format

--- a/lib/analysisfunctions.py
+++ b/lib/analysisfunctions.py
@@ -310,7 +310,7 @@ def getfieldaverageinbox(x1, x2, y1, y2, z1, z2, dfields, fieldkey):
     return avgfield
 
 
-def compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock):
+def compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock, xlim=None, ylim=None, zlim=None):
     """
     Computes f(x; vy, vx), CEx(x; vy, vx), and CEx(x; vy, vx) along different slices of x
 
@@ -318,7 +318,7 @@ def compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock):
     ----------
     dfields : dict
         field data dictionary from field_loader
-    dpar : dict
+    dparticles : dict
         xx vx yy vy data dictionary from readParticlesPosandVelocityOnly
     vmax : float
         specifies signature domain in velocity space
@@ -329,6 +329,12 @@ def compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock):
         width of x slice
     vshock : float
         velocity of shock in x direction
+    xlim : array
+        array of limits in x, defaults to None
+    ylim : array
+        array of limits in y, defaults to None
+    zlim : array
+        array of limits in z, defaults to None
 
     Returns
     -------
@@ -356,17 +362,34 @@ def compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock):
     x_out = []
     Hist_out = []
 
-    #TODO: make these an input parameters
-    x1 = dfields['ex_xx'][0]
-    x2 = dfields['ex_xx'][1]
-    y1 = dfields['ex_yy'][0]
-    y2 = dfields['ex_yy'][1]
-    z1 = dfields['ex_zz'][0]
-    z2 = dfields['ex_zz'][1]
+    if xlim is not None:
+        x1 = xlim[0]
+        x2 = x1+dx
+        xEnd = xlim[1]
+    # If xlim is None, use lower x edge to upper x edge extents
+    else:
+        x1 = dfields['ex_xx'][0]
+        x2 = x1 + dx
+        xEnd = dfields['ex_xx'][-1]
+    if ylim is not None:
+        y1 = ylim[0]
+        y2 = ylim[1]
+    # If ylim is None, use lower y edge to lower y edge + dx extents
+    else:
+        y1 = dfields['ex_yy'][0]
+        y2 = y1 + dx
+    if zlim is not None:
+        z1 = zlim[0]
+        z2 = zlim[1]
+    # If zlim is None, use lower z edge to lower z edge + dx extents
+    else:
+        z1 = dfields['ex_zz'][0]
+        z2 = z1 + dx 
 
-    i = 0
-    while(x2 <= dfields['ex_xx'][-1]):
-        print(str(dfields['ex_xx'][i]) +' of ' + str(dfields['ex_xx'][len(dfields['ex_xx'])-1]))
+    #i = 0
+    while(x2 <= xEnd):
+        # This print statement is no longer correct now that we are taking the start points as inputs
+        #print(str(dfields['ex_xx'][i]) +' of ' + str(dfields['ex_xx'][len(dfields['ex_xx'])-1]))
         vx, vy, vz, totalPtcl, totalFieldpts, Hist, CEx = compute_hist_and_cor(vmax, dv, x1, x2, y1, y2, z1, z2, dparticles, dfields, vshock, 'ex', 'x')
         vx, vy, vz, totalPtcl, totalFieldpts, Hist, CEy = compute_hist_and_cor(vmax, dv, x1, x2, y1, y2, z1, z2, dparticles, dfields, vshock, 'ey', 'y')
         vx, vy, vz, totalPtcl, totalFieldpts, Hist, CEz = compute_hist_and_cor(vmax, dv, x1, x2, y1, y2, z1, z2, dparticles, dfields, vshock, 'ez', 'z')
@@ -377,7 +400,7 @@ def compute_correlation_over_x(dfields, dparticles, vmax, dv, dx, vshock):
         Hist_out.append(Hist)
         x1+=dx
         x2+=dx
-        i+=1
+        #i+=1
 
     return CEx_out, CEy_out, CEz_out, x_out, Hist_out, vx, vy, vz
 

--- a/lib/loadfunctions.py
+++ b/lib/loadfunctions.py
@@ -373,8 +373,13 @@ def analysis_input():
     """
     flnm = 'analysisinput.txt'
 
-    #get file object
+    # Get file object
     f = open("analysisinput.txt", "r")
+    # Initialize optional input arguments to None
+    dx = None
+    xlim = None
+    ylim = None
+    zlim = None
 
     while(True):
         #read next line
@@ -394,8 +399,16 @@ def analysis_input():
             dv = float(line[1])
         elif(line[0]=='numframe'):
             numframe = int(line[1])
+        elif(line[0]=='dx'):
+            dx = float(line[1])
+        elif(line[0]=='xlim'):
+            xlim = [float(line[1].split(",")[0]), float(line[1].split(",")[1])]
+        elif(line[0]=='ylim'):
+            ylim = [float(line[1].split(",")[0]), float(line[1].split(",")[1])]
+        elif(line[0]=='zlim'):
+            zlim = [float(line[1].split(",")[0]), float(line[1].split(",")[1])]
 
     #close file
     f.close()
 
-    return path,vmax,dv,numframe
+    return path,vmax,dv,numframe,dx,xlim,ylim,zlim


### PR DESCRIPTION
If these inputs are not specified dx defaults to the grid spacing and we load all the particles, but this way we only load the particles we need. Likewise, this makes it such that we don't compute the correlations over the entire x domain, which includes things like the far upstream and downstream (which are currently of less interest).